### PR TITLE
fixing error while running get_theorem_prover_labels.py

### DIFF
--- a/common.py
+++ b/common.py
@@ -202,8 +202,11 @@ class Theory:
             constants = arguments_in_theory - set(all_variables)
             args_to_choose_from = set(constants)
             num_missing_constants = num_arguments - len(constants)
-            if num_missing_constants > 0 :
-                args_to_choose_from.add(random.sample(variables, num_missing_constants))
+
+            if num_missing_constants > 0:
+                    sampled_vars = random.sample(variables, num_missing_constants)
+                args_to_choose_from.update(set(sampled_vars))
+
             arguments = random.sample(args_to_choose_from, num_arguments)
             fact = Fact('+', predicate, arguments, 0.0)
             return fact


### PR DESCRIPTION
Fixing error while running get_theorem_prover_labels.py

"/..../ruletaker/common.py", line 206, in create_fact
    args_to_choose_from.add(random.sample(variables,
num_missing_constants))
TypeError: unhashable type: 'list'

Fix: common.py line 206
When num of sampled_vars > 1, args_to_choose_from.add() fails

Fixed code:
            if num_missing_constants > 0:
                sampled_vars = random.sample(variables,
num_missing_constants)
                args_to_choose_from.update(set(sampled_vars))