### PR TITLE
Remove support for PyDatalog

### DIFF
--- a/common.py
+++ b/common.py
@@ -38,15 +38,6 @@ class Fact:
             lf += f'{self.predicate}({", ".join(arguments)})'
             if standalone:
                 lf = f'{prob}{lf}.'
-        elif theorem_prover.lower() == 'pydatalog':
-            args_txt = ', '.join(arguments)
-            lf = None
-            if self.polarity == '+':
-                lf = f'{self.predicate}({args_txt})'
-            else:
-                lf = f'~{self.predicate}({args_txt})'
-            if standalone:
-                lf = f'+{lf}' 
         return lf
 
     def nl(self, standalone=True):
@@ -111,13 +102,6 @@ class Rule:
             antecedant_lf = ', '.join([lhs_fact.logical_form(theorem_prover, False) for lhs_fact in self.lhs])
             consequent_lf = self.rhs.logical_form(theorem_prover, False)
             lf = f'{prob}{consequent_lf} :- {antecedant_lf}.'
-        elif theorem_prover.lower() == 'pydatalog':
-            fact_txts = []
-            for fact in self.lhs:
-                fact_txts.append(fact.logical_form(theorem_prover, False))
-            antecedant = ' & '.join(fact_txts)
-            consequent = self.rhs.logical_form(theorem_prover, False) 
-            lf = f'{consequent} <= {antecedant}'
         return lf
 
     def nl(self):
@@ -179,11 +163,6 @@ class Theory:
         """The program along with assertion in theorem proving engine's expected format."""
         if theorem_prover == 'problog':
             return self.program(theorem_prover, assertion)
-        elif theorem_prover == 'pydatalog':
-            program = self.program(theorem_prover)
-            assertion_lf = assertion.logical_form(theorem_prover)
-            program += f'\nask({assertion_lf})'
-            return program 
         else:
             return self.program(theorem_prover, assertion)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ Cython==0.29.21
 nltk==3.5
 numpy==1.19.0
 problog==2.1.0.42
-pyDatalog==0.17.1
 PySDD==0.2.10

--- a/theory_label_generator.py
+++ b/theory_label_generator.py
@@ -327,7 +327,7 @@ def main():
     """
     parser = argparse.ArgumentParser(description='Tool to run theories through a theorem prover.')
     parser.add_argument('--ruletaker-dataset-jsonl', required=True, help='Jsonl file containing train or dev set theory-assertion instances with labels in RuleTaker format')
-    parser.add_argument('--theorem-prover', required=True, choices=['problog'], help='Json format config file with parameters to generate theory')
+    parser.add_argument('--theorem-prover', default='problog', help='Thorem proving engine to use. Only supported one right now is problog.')
     parser.add_argument('--theorem-prover-op-jsonl', required=True, help='Output jsonl file containing the theorem prover\'s output for each theory-assertion instance input')
     parser.add_argument('--report-metrics', action='store_true', help='Flag that will cause metrics (accuracy against gold labels) to be tracked and reported')
     args = parser.parse_args()


### PR DESCRIPTION
We experimented with using both PyDatalog and Problog and settled on using Problog. There are some edge cases with PyDatalog that lead to bugs with the theory generation. It would be confusing to keep all the code without assurance on if it will work properly, hence best to drop support for it now, before we release this thing.