### PR TITLE
Show progress in theory generator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Cython==0.29.21
 nltk==3.5
 numpy==1.19.0
 problog==2.1.0.42
-PySDD==0.2.10
+tqdm==4.51.0

--- a/theory_generator.py
+++ b/theory_generator.py
@@ -18,6 +18,8 @@ from problog.engine_stack import NegativeCycle
 from problog.formula import LogicFormula, LogicDAG
 from problog.sdd_formula import SDD 
 
+from tqdm.auto import tqdm
+
 import utils
 from utils import parse_fact, parse_rule
 
@@ -304,6 +306,8 @@ def generate_theory(grammar, config, theory_lf_file, theory_program_file, theory
     num_true_labels = 0
     num_false_labels = 0
     curr_num_examples = 0
+    progress_tracker = tqdm(total=num_examples)
+    progress_tracker.set_description(desc="Generating Examples...")
     while curr_num_examples < num_examples:
         example = generate_random_example(grammar, \
             theorem_prover_config, \
@@ -325,6 +329,8 @@ def generate_theory(grammar, config, theory_lf_file, theory_program_file, theory
             if theory_english_writer is not None:
                 theory_english_writer.writerow([theory_in_nl, assertion_in_nl, example.label])    
             curr_num_examples += 1
+            progress_tracker.update()
+    progress_tracker.close()
     print(f'Generated {curr_num_examples} examples.')
     print(f'  No. with True label: {num_true_labels}')
     print(f'  No. with False label: {num_false_labels}')      


### PR DESCRIPTION
@aimichal : Progress is shown like below--

<img width="800" alt="Screen Shot 2020-11-12 at 1 41 23 PM" src="https://user-images.githubusercontent.com/5631150/98999849-42b5ec80-24ed-11eb-924a-b51d51250e69.png">

<img width="801" alt="Screen Shot 2020-11-12 at 1 42 16 PM" src="https://user-images.githubusercontent.com/5631150/98999842-4184bf80-24ed-11eb-8cc2-ad4a5ec42957.png">

Also went ahead and got rid of the `PySDD` dependency in `requirments.txt`.